### PR TITLE
Release v1.0.9p4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Add missing logic for MQTT ```commands``` subscription with new ```commands``` e
   - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
   - Fixed warning on g_ad2_console_mutex.
 ### Change log
-  = [X] SM - MISC: Fix small memory leak in virtual switch usage in Pushover, Twilio and MQTT.
+  - [X] SM - MISC: Fix small memory leak in virtual switch usage in Pushover, Twilio and MQTT.
   - [X] SM - MQTT: Refactor publish function to make it easy to use in the code.
   - [X] SM - HAL: Added hal wrapper for ota_do_update(hal_ota_do_update) and updated any use of ota_do_update from outside of main.
   - [X] SM - MQTT: Added commands verbs ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Add missing logic for MQTT ```commands``` subscription with new ```commands``` e
   - Remove unnecessary code passed to ad2_ functions that don't need it.
   - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
   - Fixed warning on g_ad2_console_mutex.
+### Change log
+  [ ] SM - MQTT: Support for Home Assistant/Others auto discovery.
+  [X] SM - MQTT: Add new command ```commands``` to enable/disable commands subscription.
+  [X] SM - MQTT: Remove forced cdecl calling to use C++.
+  [ ] SM - MQTT: Add new command ```prefix``` to set a prefix for all topics on the broker.
+  [X] SM - MQTT: Add new command to define signon messages to publish.
+  [X] SM - CORE: Refactor ad2_ routines to arm, disarm etc to support raw code as well as code id from ```code``` command.
+  [X] SM - CORE: ad2_utils remove forced cdecl calling to use C++ instead. TODO: I can now safely remove the extern 'C' from everything with the current build tools.
+  [X] SM - CORE: Fixed a few compiler warnings re. external with init.
 
 ## [1.0.9 P3] - 2021-11-22 Sean Mathews - coder @f34rdotcom
 Continued improvements found during daily use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Add missing logic for MQTT ```commands``` subscription with new ```commands``` e
   - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
   - Fixed warning on g_ad2_console_mutex.
 ### Change log
+  = [X] SM - MISC: Fix small memory leak in virtual switch usage in Pushover, Twilio and MQTT.
   - [X] SM - MQTT: Refactor publish function to make it easy to use in the code.
   - [X] SM - HAL: Added hal wrapper for ota_do_update(hal_ota_do_update) and updated any use of ota_do_update from outside of main.
   - [X] SM - MQTT: Added commands verbs ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 ## Releases
+## [1.0.9 P4] - 2022-02-XX Sean Mathews - coder @fe4rdotcom
+Add missing logic for MQTT ```commands``` subscription with new ```commands``` enable/disable command. Misc minor cleanup of warnings. Refactor ad2_ helpers for arming to support code or codeID.
+### Added
+  - Enable/Disable feature for ```commands``` subscription with warning when enabling about security on public MQTT servers.
+    - ```mqtt commands [Y|N]```
+  - Missing logic behind ```commands``` subscription in the MQTT component.
+  - Update README with details on ```commands```.
+  - Refactor utils to allow for raw codes or codeID for ARM, DISARM, etc.
+  - Remove unnecessary code passed to ad2_ functions that don't need it.
+  - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
+  - Fixed warning on g_ad2_console_mutex.
+
 ## [1.0.9 P3] - 2021-11-22 Sean Mathews - coder @f34rdotcom
 Continued improvements found during daily use.
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 ## Releases
-## [1.0.9 P4] - 2022-02-XX Sean Mathews - coder @f34rdotcom
+## [1.0.9 P4] - 2022-02-22 Sean Mathews - coder @f34rdotcom
 Add missing logic for MQTT ```commands``` subscription with new ```commands``` enable/disable command. Misc minor cleanup of warnings. Refactor ad2_ helpers for arming to support code or codeID. Added initial support for Auto Discovery with Home Assistant and MQTT.
 ### Added
   - MQTT
@@ -43,12 +43,15 @@ Add missing logic for MQTT ```commands``` subscription with new ```commands``` e
     - Add topic prefix command ```tprefix```.
     - Add discovery topic prefix command ```dprefix``` for MQTT auto discovery.
 ### Changed
+  - Change ```zone``` command to expect a json string that is not currently validated as the last argument.
+    - ```{"alpha": "zone alpha descriptor", "type": "zone type string"}```.
   - Refactor utils to allow for raw codes or codeID for ARM, DISARM, etc.
   - Remove unnecessary code passed to ad2_ functions that don't need it.
   - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
   - Fixed warning on g_ad2_console_mutex.
 ### Change log
-  - [X] SM - Added hal wrapper for ota_do_update(hal_ota_do_update) and updated any use of ota_do_update from outside of main.
+  - [X] SM - MQTT: Refactor publish function to make it easy to use in the code.
+  - [X] SM - HAL: Added hal wrapper for ota_do_update(hal_ota_do_update) and updated any use of ota_do_update from outside of main.
   - [X] SM - MQTT: Added commands verbs ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```.
   - [X] SM - MQTT: Support for Home Assistant/Others auto discovery.
   - [X] SM - MQTT: Add new command ```dprefix``` to set a prefix for publishing device config documents for MQTT auto discovery.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,21 +32,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ---
 ## Releases
 ## [1.0.9 P4] - 2022-02-XX Sean Mathews - coder @fe4rdotcom
-Add missing logic for MQTT ```commands``` subscription with new ```commands``` enable/disable command. Misc minor cleanup of warnings. Refactor ad2_ helpers for arming to support code or codeID.
+Add missing logic for MQTT ```commands``` subscription with new ```commands``` enable/disable command. Misc minor cleanup of warnings. Refactor ad2_ helpers for arming to support code or codeID. Added initial support for Auto Discovery with Home Assistant and MQTT.
 ### Added
-  - Enable/Disable feature for ```commands``` subscription with warning when enabling about security on public MQTT servers.
+  - MQTT
+    - Enable/Disable feature for ```commands``` subscription with warning when enabling about security on public MQTT servers.
     - ```mqtt commands [Y|N]```
-  - Missing logic behind ```commands``` subscription in the MQTT component.
-  - Update README with details on ```commands```.
+    - Missing logic behind ```commands``` subscription in the MQTT component.
+    - Update README with details on ```commands```, ```tprefix``` and ```dprefix```.
+    - Add topic prefix command ```tprefix```.
+    - Add discovery topic prefix command ```dprefix``` for MQTT auto discovery.
+### Changed
   - Refactor utils to allow for raw codes or codeID for ARM, DISARM, etc.
   - Remove unnecessary code passed to ad2_ functions that don't need it.
   - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
   - Fixed warning on g_ad2_console_mutex.
 ### Change log
-  [ ] SM - MQTT: Support for Home Assistant/Others auto discovery.
+  [X] SM - MQTT: Support for Home Assistant/Others auto discovery.
+  [X] SM - MQTT: Add new command ```dprefix``` to set a prefix for publishing device config documents for MQTT auto discovery.
   [X] SM - MQTT: Add new command ```commands``` to enable/disable commands subscription.
   [X] SM - MQTT: Remove forced cdecl calling to use C++.
-  [ ] SM - MQTT: Add new command ```prefix``` to set a prefix for all topics on the broker.
+  [X] SM - MQTT: Add new command ```tprefix``` to set a prefix for all topics on the broker.
   [X] SM - MQTT: Add new command to define signon messages to publish.
   [X] SM - CORE: Refactor ad2_ routines to arm, disarm etc to support raw code as well as code id from ```code``` command.
   [X] SM - CORE: ad2_utils remove forced cdecl calling to use C++ instead. TODO: I can now safely remove the extern 'C' from everything with the current build tools.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 ## Releases
-## [1.0.9 P4] - 2022-02-XX Sean Mathews - coder @fe4rdotcom
+## [1.0.9 P4] - 2022-02-XX Sean Mathews - coder @f34rdotcom
 Add missing logic for MQTT ```commands``` subscription with new ```commands``` enable/disable command. Misc minor cleanup of warnings. Refactor ad2_ helpers for arming to support code or codeID. Added initial support for Auto Discovery with Home Assistant and MQTT.
 ### Added
   - MQTT
     - Enable/Disable feature for ```commands``` subscription with warning when enabling about security on public MQTT servers.
-    - ```mqtt commands [Y|N]```
+      - ```mqtt commands [Y|N]```
     - Missing logic behind ```commands``` subscription in the MQTT component.
+      - Verbs: ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```
     - Update README with details on ```commands```, ```tprefix``` and ```dprefix```.
     - Add topic prefix command ```tprefix```.
     - Add discovery topic prefix command ```dprefix``` for MQTT auto discovery.
@@ -47,15 +48,17 @@ Add missing logic for MQTT ```commands``` subscription with new ```commands``` e
   - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
   - Fixed warning on g_ad2_console_mutex.
 ### Change log
-  [X] SM - MQTT: Support for Home Assistant/Others auto discovery.
-  [X] SM - MQTT: Add new command ```dprefix``` to set a prefix for publishing device config documents for MQTT auto discovery.
-  [X] SM - MQTT: Add new command ```commands``` to enable/disable commands subscription.
-  [X] SM - MQTT: Remove forced cdecl calling to use C++.
-  [X] SM - MQTT: Add new command ```tprefix``` to set a prefix for all topics on the broker.
-  [X] SM - MQTT: Add new command to define signon messages to publish.
-  [X] SM - CORE: Refactor ad2_ routines to arm, disarm etc to support raw code as well as code id from ```code``` command.
-  [X] SM - CORE: ad2_utils remove forced cdecl calling to use C++ instead. TODO: I can now safely remove the extern 'C' from everything with the current build tools.
-  [X] SM - CORE: Fixed a few compiler warnings re. external with init.
+  - [X] SM - Added hal wrapper for ota_do_update(hal_ota_do_update) and updated any use of ota_do_update from outside of main.
+  - [X] SM - MQTT: Added commands verbs ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```.
+  - [X] SM - MQTT: Support for Home Assistant/Others auto discovery.
+  - [X] SM - MQTT: Add new command ```dprefix``` to set a prefix for publishing device config documents for MQTT auto discovery.
+  - [X] SM - MQTT: Add new command ```commands``` to enable/disable commands subscription.
+  - [X] SM - MQTT: Remove forced cdecl calling to use C++.
+  - [X] SM - MQTT: Add new command ```tprefix``` to set a prefix for all topics on the broker.
+  - [X] SM - MQTT: Add new command to define signon messages to publish.
+  - [X] SM - CORE: Refactor ad2_ routines to arm, disarm etc to support raw code as well as code id from ```code``` command.
+  - [X] SM - CORE: ad2_utils remove forced cdecl calling to use C++ instead. TODO: I can now safely remove the extern 'C' from everything with the current build tools.
+  - [X] SM - CORE: Fixed a few compiler warnings re. external with init.
 
 ## [1.0.9 P3] - 2021-11-22 Sean Mathews - coder @f34rdotcom
 Continued improvements found during daily use.

--- a/README.md
+++ b/README.md
@@ -229,16 +229,16 @@ Configuration is currently only available over the USB serial port using a comma
     - Remove virtual partition in slot 2.
       - ```vpart 2 -1```
        - Note: address -1 will remove an entry.
-- Manage zone strings.
+- Manage zone settings string.
   - ```zone {id} [value]```
     - {id}
       - Zone number 1-255.
     - [value]
-      - An alpha string for the zone.
+      - json zone settings string for this zone.
   - Examples
-    - Set zone 1 alpha string.
-      - ```zone 1 TESTING LAB```
-    - Remove zone 1 alpha string.
+    - Set zone 1 configuration string.
+      - ```zone 1 {"type": "smoke", "alpha": "TESTING LAB SMOKE"}```
+    - Remove zone 1 settings string.
       - ```zone 1 ''```
 - Manage AlarmDecoder protocol source.
   - ```ad2source [{mode} {arg}]```
@@ -528,63 +528,36 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
 
 - Implementation notes:
   - Each client connects under the root topic of ```ad2iot``` with a sub topic level of the devices UUID.
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX```
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX```
   - Last Will and Testament (LWT) is used to indicate ```online```/```offline``` ```state``` of client using ```status``` topic below the device root topic.
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/status = {"state": "online"}```
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/status = online```
   - Device specific info is in the ```info``` topic below the device root topic.
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/info = {"firmware_version":"AD2IOT-1094","cpu_model":1,"cpu_revision":1,"cpu_cores":2,"cpu_features":["WiFi","BLE","BT"],"cpu_flash_size":4194304,"cpu_flash_type":"external","ad2_version_string":"08000002,V2.2a.8.9b-306,TX;RX;SM;VZ;RF;ZX;RE;AU;3X;CG;DD;MF;L2;KE;M2;CB;DS;ER;CR","ad2_config_string":"MODE=A&CONFIGBITS=ff05&ADDRESS=18&LRR=Y&COM=N&EXP=YYNNN&REL=YNNN&MASK=ffffffff&DEDUPLICATE=N"}```
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/info = {"firmware_version":"AD2IOT-1094","cpu_model":1,"cpu_revision":1,"cpu_cores":2,"cpu_features":["WiFi","BLE","BT"],"cpu_flash_size":4194304,"cpu_flash_type":"external","ad2_version_string":"08000002,V2.2a.8.9b-306,TX;RX;SM;VZ;RF;ZX;RE;AU;3X;CG;DD;MF;L2;KE;M2;CB;DS;ER;CR","ad2_config_string":"MODE=A&CONFIGBITS=ff05&ADDRESS=18&LRR=Y&COM=N&EXP=YYNNN&REL=YNNN&MASK=ffffffff&DEDUPLICATE=N"}```
   - Topic prefix when configrued with ```tprefix``` will prefix all publish topics with a specified path.
-    - Example: Place ```ad2iot``` topic under the Home Assistant topic.
+    - Example: Place ```ad2iot``` topic under the ```homeassistant``` topic.
       - ```tprefix homeassistant```
-  - Auto discovery device config if enabled with ```dprefix``` will publish the alarm panel device config for each partition and zone that is configured. See https://www.home-assistant.io/docs/mqtt/discovery/
+  - Auto Discovery topic ```dprefix``` will publish the alarm panel device config for each partition, zone, and sensor configured. See https://www.home-assistant.io/docs/mqtt/discovery/
     - Example: Place discovery topic under Home Assistant.
       - ```dtopic homeassistant```
   - Partition state tracking with minimal traffic only when state changes. Each configured partition will be under the ```partitions``` topic below the device root topic.
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/partitions/1 =
 {"ready":false,"armed_away":false,"armed_stay":false,"backlight_on":false,"programming_mode":false,"zone_bypassed":false,"ac_power":true,"chime_on":false,"alarm_event_occurred":false,"alarm_sounding":false,"battery_low":true,"entry_delay_off":false,"fire_alarm":false,"system_issue":false,"perimeter_only":false,"exit_now":false,"system_specific":3,"beeps":0,"panel_type":"A","last_alpha_messages":"SYSTEM LO BAT                   ","last_numeric_messages":"008","event":"LOW BATTERY"}```
-  - Custom virtual switches with user defined topics are kept under the ```switches``` below the device root topic.
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/switches/RF0180036 = {"state":"RF SENSOR 0180036 CLOSED"}```
-  - Zone states by Zone ID(NNN) are kept under the ```zones``` below the device root topic.
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/zones/003 = {"state":"CLOSE","partition":2,"name":"THIS IS ZONE 3"}```
+  - Custom virtual switches with user defined topics are under the ```switches``` below the device root topic.
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/switches/RF0123456 = {"state":"ON"}```
+  - Zone states by Zone ID(NNN) are under the ```zones``` below the device root topic.
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/zones/003 = {"state":"CLOSE","partition":2,"name":"THIS IS ZONE 3"}```
   - Remote ```commands``` subscription. If enabled the device will subscribe to ```commands``` below the device root topic. Warning! Only enable if on a secure broker as codes will be visible to subscribers.
     - Publish JSON template ```{ "vpart": {number}, "action": "{string}", "code": "{string}", "arg": "{string}"}```
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "DISARM", "code": "1234"}```
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "BYPASS", "code": "1234", "arg": "03"}```
-    - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "FIRE_ALARM"}```
-    - Example (tested) Home Assistant(HA) MQTT Alarm Control Panel yaml.
-      ```
-      alarm_control_panel:
-        - platform: mqtt
-          name: "AlarmDecoder IoT partition 1"
-          availability_topic: "ad2iot/{UUID}/status"
-          availability_template: "{{ value_json.state }}"
-          state_topic: "ad2iot/{UUID}/partitions/1"
-          command_topic: "ad2iot/{UUID}/commands"
-          code: REMOTE_CODE
-          # available command verbs ["DISARM", "ARM_STAY", "ARM_AWAY", "EXIT", "CHIME_TOGGLE", "AUX_ALARM", "PANIC_ALARM", "FIRE_ALARM", "BYPASS", "SEND_RAW"]
-          payload_arm_home: "ARM_STAY"
-          payload_trigger: "PANIC_ALARM"
-          command_template: '{ "vpart": 0, "action": "{{ action }}", "code": "{{ code }}"}'
-          value_template: >-
-              {% if value_json.alarm_sounding == true or value_json.alarm_event_occurred == true %}
-                  triggered
-              {% elif value_json.armed_stay == true %}
-                  {% if value_json.entry_delay_off == true %}
-                      armed_night
-                  {% else %}
-                      armed_home
-                  {% endif %}
-              {% elif value_json.armed_away == true %}
-                  {% if value_json.entry_delay_off == true %}
-                      armed_vacation
-                  {% elif value_json.entry_delay_off == false %}
-                      armed_away
-                  {% endif %}
-              {% else %}
-                  disarmed
-              {% endif %}
-      ```
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "DISARM", "code": "1234"}```
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "BYPASS", "code": "1234", "arg": "03"}```
+    - Example: ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "FIRE_ALARM"}```
+  - Contact ID reporting if found will be published to ```[{tprefix}/]ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/cid```
+    - Example: ```{ "event_message": "!LRR:002,1,CID_3441,ff"}```
 
+  - Home Assistant intigration.
+    - Configure ```dprefix``` to ```homeassistant``` or the location you have configured HA to look for MQTT discovery topics.
+    - Optional configure ```tprefix``` to ```homeassistant``` to force the ```ad2iot``` topic to be under the default HA mqtt topic.
+    - MQTT Auto Discovery setup See https://www.home-assistant.io/docs/mqtt/discovery/
 ####  5.7.1. <a name='configuration-for-mqtt-message-notifications'></a>Configuration for MQTT message notifications
 - Publishes the virtual partition state using the following topic pattern.
   - ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/partitions/Y
@@ -606,9 +579,9 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
   - ```mqtt commands [Y/N]```
   -  {arg1}: [Y]es [N]o
   - Example: ```mqtt commands Y```
-- Home Assistant discovery prefix. If set will enable publishing donfig details.
+- MQTT auto discovery prefix for topic to publish config documents.
   - ```mqtt dprefix {prefix}```
-  -  {prefix}: Home Assistant topic.
+  -  {prefix}: MQTT auto discovery topic root.
   - Example: ```mqtt dprefix homeassistant```
 - Define a smart virtual switch that will track and alert alarm panel state changes using user configurable filter and formatting rules.
   - ```mqtt switch {slot} {setting} {arg1} [arg2]```
@@ -661,11 +634,11 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
   # Set 'TROUBLE' state REGEX Filter [F] #01.
   mqtt switch 1 F 1 !RFX:0123456,......1.
   # Set output format string for 'OPEN' state [o].
-  mqtt switch 1 o RF SENSOR 0123456 OPEN
+  mqtt switch 1 o OFF
   # Set output format string for 'CLOSED' state [c].
-  mqtt switch 1 c RF SENSOR 0123456 CLOSED
+  mqtt switch 1 c ON
   # Set output format string for 'TROUBLE' stat
-  mqtt switch 1 f RF SENSOR 0123456 TROUBLE
+  mqtt switch 1 f OFF
   ```
 
 ##  6. <a name='building-firmware'></a>Building firmware

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
             {% endif %}
           command_topic: "ad2iot/{UUID}/commands"
           code: REMOTE_CODE
-          # available command verbs ["DISARM", "ARM_STAY", "ARM_AWAY", "EXIT", "AUX_ALARM", "PANIC_ALARM", "FIRE_ALARM", "BYPASS", "SEND_RAW"]
+          # available command verbs ["DISARM", "ARM_STAY", "ARM_AWAY", "EXIT", "CHIME_TOGGLE", "AUX_ALARM", "PANIC_ALARM", "FIRE_ALARM", "BYPASS", "SEND_RAW"]
           payload_arm_home: "ARM_STAY"
           payload_trigger: "PANIC_ALARM"
           command_template: "{ vpart: 0, action: '{{ action }}', code: {{ code }}} }"

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "DISARM", "code": "1234"}```
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "BYPASS", "code": "1234", "arg": "03"}```
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/commands = {"vpart": 0, "action": "FIRE_ALARM"}```
-    - Example(not tested) Home Assistant(HA) MQTT Alarm Control Panel yaml.
+    - Example (tested) Home Assistant(HA) MQTT Alarm Control Panel yaml.
       ```
       alarm_control_panel:
         - platform: mqtt
@@ -553,24 +553,30 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
           availability_topic: "ad2iot/{UUID}/status"
           availability_template: "{{ value_json.state }}"
           state_topic: "ad2iot/{UUID}/partitions/1"
-          value_template: >
-            {% if value_json.alarm_sounding == true || value_json.alarm_event_occurred == true %}triggered
-            {% elif value_json.armed_stay == true %}
-              {% if value_json.entry_delay_off == true %}armed_night
-              {% elif value_json.entry_delay_off == false %}armed_home
-              {% endif }
-            {% elif value_json.armed_away == true %}
-              {% if value_json.entry_delay_off == true %}armed_vacation
-              {% elif value_json.entry_delay_off == false %}armed_away
-              {% endif }
-            {% else %}disarmed
-            {% endif %}
           command_topic: "ad2iot/{UUID}/commands"
           code: REMOTE_CODE
           # available command verbs ["DISARM", "ARM_STAY", "ARM_AWAY", "EXIT", "CHIME_TOGGLE", "AUX_ALARM", "PANIC_ALARM", "FIRE_ALARM", "BYPASS", "SEND_RAW"]
           payload_arm_home: "ARM_STAY"
           payload_trigger: "PANIC_ALARM"
-          command_template: "{ vpart: 0, action: '{{ action }}', code: {{ code }}} }"
+          command_template: '{ "vpart": 0, "action": "{{ action }}", "code": "{{ code }}"}'
+          value_template: >-
+              {% if value_json.alarm_sounding == true or value_json.alarm_event_occurred == true %}
+                  triggered
+              {% elif value_json.armed_stay == true %}
+                  {% if value_json.entry_delay_off == true %}
+                      armed_night
+                  {% else %}
+                      armed_home
+                  {% endif %}
+              {% elif value_json.armed_away == true %}
+                  {% if value_json.entry_delay_off == true %}
+                      armed_vacation
+                  {% elif value_json.entry_delay_off == false %}
+                      armed_away
+                  {% endif %}
+              {% else %}
+                  disarmed
+              {% endif %}
       ```
 
 ####  5.7.1. <a name='configuration-for-mqtt-message-notifications'></a>Configuration for MQTT message notifications

--- a/README.md
+++ b/README.md
@@ -533,6 +533,12 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/status = {"state": "online"}```
   - Device specific info is in the ```info``` topic below the device root topic.
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/info = {"firmware_version":"AD2IOT-1094","cpu_model":1,"cpu_revision":1,"cpu_cores":2,"cpu_features":["WiFi","BLE","BT"],"cpu_flash_size":4194304,"cpu_flash_type":"external","ad2_version_string":"08000002,V2.2a.8.9b-306,TX;RX;SM;VZ;RF;ZX;RE;AU;3X;CG;DD;MF;L2;KE;M2;CB;DS;ER;CR","ad2_config_string":"MODE=A&CONFIGBITS=ff05&ADDRESS=18&LRR=Y&COM=N&EXP=YYNNN&REL=YNNN&MASK=ffffffff&DEDUPLICATE=N"}```
+  - Topic prefix when configrued with ```tprefix``` will prefix all publish topics with a specified path.
+    - Example: Place ```ad2iot``` topic under the Home Assistant topic.
+      - ```tprefix homeassistant```
+  - Auto discovery device config if enabled with ```dprefix``` will publish the alarm panel device config for each partition and zone that is configured. See https://www.home-assistant.io/docs/mqtt/discovery/
+    - Example: Place discovery topic under Home Assistant.
+      - ```dtopic homeassistant```
   - Partition state tracking with minimal traffic only when state changes. Each configured partition will be under the ```partitions``` topic below the device root topic.
     - Example: ```ad2iot/41443245-4d42-4544-4410-XXXXXXXXXXXX/partitions/1 =
 {"ready":false,"armed_away":false,"armed_stay":false,"backlight_on":false,"programming_mode":false,"zone_bypassed":false,"ac_power":true,"chime_on":false,"alarm_event_occurred":false,"alarm_sounding":false,"battery_low":true,"entry_delay_off":false,"fire_alarm":false,"system_issue":false,"perimeter_only":false,"exit_now":false,"system_specific":3,"beeps":0,"panel_type":"A","last_alpha_messages":"SYSTEM LO BAT                   ","last_numeric_messages":"008","event":"LOW BATTERY"}```
@@ -591,11 +597,19 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
 - Sets the URL to the MQTT broker.
   - ```mqtt url {url}```
     - {url}: MQTT broker URL.
-  - Example: ```mqtt url mqtt://mqtt.eclipseprojects.io```
+  - Example: ```mqtt url mqtt://user@pass:mqtt.example.com```
+- Topic prefix. Prefix to be used on publish topics.
+  - ```mqtt tprefix {prefix}```
+  -  {prefix}: Topic prefix.
+  - Example: ```mqtt tprefix somepath```
 - Enable/Disable command subscription. Do not enable on public MQTT servers!
   - ```mqtt commands [Y/N]```
   -  {arg1}: [Y]es [N]o
   - Example: ```mqtt commands Y```
+- Home Assistant discovery prefix. If set will enable publishing donfig details.
+  - ```mqtt dprefix {prefix}```
+  -  {prefix}: Home Assistant topic.
+  - Example: ```mqtt dprefix homeassistant```
 - Define a smart virtual switch that will track and alert alarm panel state changes using user configurable filter and formatting rules.
   - ```mqtt switch {slot} {setting} {arg1} [arg2]```
     - {slot}

--- a/README.md
+++ b/README.md
@@ -634,11 +634,11 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
   # Set 'TROUBLE' state REGEX Filter [F] #01.
   mqtt switch 1 F 1 !RFX:0123456,......1.
   # Set output format string for 'OPEN' state [o].
-  mqtt switch 1 o OFF
+  mqtt switch 1 o ON
   # Set output format string for 'CLOSED' state [c].
-  mqtt switch 1 c ON
+  mqtt switch 1 c OFF
   # Set output format string for 'TROUBLE' stat
-  mqtt switch 1 f OFF
+  mqtt switch 1 f ON
   ```
 
 ##  6. <a name='building-firmware'></a>Building firmware

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -207,6 +207,13 @@ static esp_err_t ad2_mqtt_event_handler(esp_mqtt_event_handle_t event_data)
             if ( event_data->topic_len == topic_path.length() ) {
                 std::string topic( event_data->topic, event_data->topic_len );
                 if ( topic.compare(topic_path) == 0 ) {
+
+                    // We only want fresh commands no recordings.
+                    // Check for retain flag skip if true.
+                    if ( event_data->retain ) {
+                        break;
+                    }
+
                     // sanity check the event_data->data_len
                     if ( event_data->data_len < MQTT_COMMAND_MAX_DATA_LEN ) {
                         std::string command( event_data->data, event_data->data_len );
@@ -246,7 +253,7 @@ static esp_err_t ad2_mqtt_event_handler(esp_mqtt_event_handle_t event_data)
                                 arg = oarg->valuestring;
                             }
 
-                            ESP_LOGI(TAG, "vpart: %i, code: '%s', action: %s, arg: %s", vpart, code.c_str(), action.c_str(), arg.c_str());
+                            ESP_LOGI(TAG, "retained: %i, vpart: %i, code: '%s', action: %s, arg: %s", event_data->retain, vpart, code.c_str(), action.c_str(), arg.c_str());
 
                             if ( action.compare("DISARM") == 0 ) {
                                 ad2_disarm(code, vpart);

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -206,8 +206,7 @@ void mqtt_send_partition_config(AD2VirtualPartitionState *s)
     // alarm_control_panel
     mqtt_publish_device_config("alarm_control_panel", "alarm_control_panel", "p",
                                s->partition, true,
-    NAME_PREFIX " Partition #", true, {
-        {
+    NAME_PREFIX " Partition #", true, {{
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.alarm_sounding == true or value_json.alarm_event_occurred == true %}triggered{% elif value_json.armed_stay == true %}{% if value_json.entry_delay_off == true %}armed_night{% else %}armed_home{% endif %}{% elif value_json.armed_away == true %}{% if value_json.entry_delay_off == true %}armed_vacation{% elif value_json.entry_delay_off == false %}armed_away{% endif %}{% else %}disarmed{% endif %}" },
             { "command_topic", topic+"/commands"},
@@ -219,45 +218,38 @@ void mqtt_send_partition_config(AD2VirtualPartitionState *s)
             { "icon", "mdi:shield-home"},
             { "sw_version", FIRMWARE_VERSION}
         }
-    }
-                              );
+    });
 
 
     // ac_power
     mqtt_publish_device_config("binary_sensor", "power", "ac_power",
                                0, false,
-    NAME_PREFIX " AC Power", false, {
-        {
+    NAME_PREFIX " AC Power", false, {{
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.ac_power == true %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
         }
-    }
-                              );
+    });
 
     // partition fire
     mqtt_publish_device_config("binary_sensor", "smoke", "fire_p",
                                s->partition, true,
-    NAME_PREFIX " Fire Partition #", true, {
-        {
+    NAME_PREFIX " Fire Partition #", true, {{
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.fire_alarm == true %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
         }
-    }
-                              );
+    });
 
     // partition chime
     mqtt_publish_device_config("binary_sensor", "running", "chime_p",
                                s->partition, true,
-    NAME_PREFIX " Chime Mode Partition #", true, {
-        {
+    NAME_PREFIX " Chime Mode Partition #", true, {{
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.chime_on == true %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
         }
-    }
-                              );
+    });
 
 }
 
@@ -319,14 +311,12 @@ void mqtt_send_partition_zone_configs(AD2VirtualPartitionState *s)
 
         mqtt_publish_device_config("binary_sensor", _type.c_str(), "zone_",
                                    zn, true,
-        _alpha.c_str(), false, {
-            {
+        _alpha.c_str(), false, {{
                 { "state_topic", topic+"/zones/"+ad2_to_string(zn) },
                 { "value_template", "{% if value_json.state == 'CLOSE' %}OFF{% else %}ON{% endif %}" },
                 { "availability_topic", topic+"/status"}
             }
-        }
-                                  );
+        });
     }
 }
 
@@ -392,27 +382,23 @@ void mqtt_on_connect(esp_mqtt_client_handle_t client)
     topic += mqttclient_UUID;
     mqtt_publish_device_config("binary_sensor", "update", "fw_version",
                                0, false,
-    NAME_PREFIX " Firmware", false, {
-        {
+    NAME_PREFIX " Firmware", false, {{
             { "state_topic", topic+"/fw_version" },
             { "value_template", "{% if value_json.installed != value_json.available %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
         }
-    }
-                              );
+    });
 
 
     mqtt_publish_device_config("button", "update", "fw_update",
                                0, false,
-    NAME_PREFIX " Start firmware update", false, {
-        {
+    NAME_PREFIX " Start firmware update", false, {{
             { "availability_topic", topic+"/fw_version" },
             { "availability_template", "{% if value_json.installed != value_json.available %}online{% else %}offline{% endif %}" },
             { "command_topic", topic+"/commands" },
             { "payload_press", "{\"action\": \"FW_UPDATE\"}" }
         }
-    }
-                              );
+    });
 
     // Publish panel config info for home assistant or others for discovery
     // for each partition that is configured with 'vpart' command.
@@ -435,16 +421,15 @@ void mqtt_on_connect(esp_mqtt_client_handle_t client)
         ad2_trim(name);
         std::string _type = "door";
 
-        mqtt_publish_device_config("binary_sensor", _type.c_str(), "switch_",
-                                   sw->INT_ARG, true,
-        name.c_str(), false, {
-            {
+        mqtt_publish_device_config(
+            "binary_sensor", _type.c_str(), "switch_",
+            sw->INT_ARG, true,
+        name.c_str(), false, {{
                 { "state_topic", topic+"/switches/"+ad2_to_string(sw->INT_ARG) },
                 { "value_template", "{{value_json.state}}" },
                 { "availability_topic", topic+"/status" }
             }
-        }
-                                  );
+        });
     }
 
 }

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -207,9 +207,9 @@ void mqtt_send_partition_config(AD2VirtualPartitionState *s)
 
     // alarm_control_panel
     mqtt_publish_device_config("alarm_control_panel", "alarm_control_panel", "p",
-        s->partition, true,
-        NAME_PREFIX " Partition #", true,
-        { {
+                               s->partition, true,
+    NAME_PREFIX " Partition #", true, {
+        {
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.alarm_sounding == true or value_json.alarm_event_occurred == true %}triggered{% elif value_json.armed_stay == true %}{% if value_json.entry_delay_off == true %}armed_night{% else %}armed_home{% endif %}{% elif value_json.armed_away == true %}{% if value_json.entry_delay_off == true %}armed_vacation{% elif value_json.entry_delay_off == false %}armed_away{% endif %}{% else %}disarmed{% endif %}" },
             { "command_topic", topic+"/commands"},
@@ -220,42 +220,46 @@ void mqtt_send_partition_config(AD2VirtualPartitionState *s)
             { "payload_trigger", "PANIC_ALARM"},
             { "icon", "mdi:shield-home"},
             { "sw_version", FIRMWARE_VERSION}
-        } }
-    );
+        }
+    }
+                              );
 
 
     // ac_power
     mqtt_publish_device_config("binary_sensor", "power", "ac_power",
-        0, false,
-        NAME_PREFIX " AC Power", false,
-        { {
+                               0, false,
+    NAME_PREFIX " AC Power", false, {
+        {
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.ac_power == true %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
-        } }
-    );
+        }
+    }
+                              );
 
     // partition fire
     mqtt_publish_device_config("binary_sensor", "smoke", "fire_p",
-        s->partition, true,
-       NAME_PREFIX " Fire Partition #", true,
-        { {
+                               s->partition, true,
+    NAME_PREFIX " Fire Partition #", true, {
+        {
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.fire_alarm == true %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
-        } }
-    );
+        }
+    }
+                              );
 
     // partition chime
     mqtt_publish_device_config("binary_sensor", "running", "chime_p",
-        s->partition, true,
-        NAME_PREFIX " Chime Mode Partition #", true,
-        { {
+                               s->partition, true,
+    NAME_PREFIX " Chime Mode Partition #", true, {
+        {
             { "state_topic", topic+"/partitions/"+szpid },
             { "value_template", "{% if value_json.chime_on == true %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
-        } }
-    );
+        }
+    }
+                              );
 
 }
 
@@ -316,14 +320,15 @@ void mqtt_send_partition_zone_configs(AD2VirtualPartitionState *s)
         AD2Parse.getZoneString(zn, _alpha);
 
         mqtt_publish_device_config("binary_sensor", _type.c_str(), "zone_",
-            zn, true,
-            _alpha.c_str(), false,
-            { {
+                                   zn, true,
+        _alpha.c_str(), false, {
+            {
                 { "state_topic", topic+"/zones/"+ad2_to_string(zn) },
                 { "value_template", "{% if value_json.state == 'CLOSE' %}OFF{% else %}ON{% endif %}" },
                 { "availability_topic", topic+"/status"}
-            } }
-        );
+            }
+        }
+                                  );
     }
 }
 
@@ -388,26 +393,28 @@ void mqtt_on_connect(esp_mqtt_client_handle_t client)
     topic = mqttclient_TPREFIX + MQTT_TOPIC_PREFIX "/";
     topic += mqttclient_UUID;
     mqtt_publish_device_config("binary_sensor", "update", "fw_version",
-        0, false,
-        NAME_PREFIX " Firmware", false,
-        { {
+                               0, false,
+    NAME_PREFIX " Firmware", false, {
+        {
             { "state_topic", topic+"/fw_version" },
             { "value_template", "{% if value_json.installed != value_json.available %}ON{% else %}OFF{% endif %}" },
             { "availability_topic", topic+"/status"}
-        } }
-    );
+        }
+    }
+                              );
 
 
     mqtt_publish_device_config("button", "update", "fw_update",
-        0, false,
-        NAME_PREFIX " Start firmware update", false,
-        { {
+                               0, false,
+    NAME_PREFIX " Start firmware update", false, {
+        {
             { "availability_topic", topic+"/fw_version" },
             { "availability_template", "{% if value_json.installed != value_json.available %}online{% else %}offline{% endif %}" },
             { "command_topic", topic+"/commands" },
             { "payload_press", "{\"action\": \"FW_UPDATE\"}" }
-        } }
-    );
+        }
+    }
+                              );
 
     // Publish panel config info for home assistant or others for discovery
     // for each partition that is configured with 'vpart' command.

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -212,7 +212,7 @@ static esp_err_t ad2_mqtt_event_handler(esp_mqtt_event_handle_t event_data)
                         std::string command( event_data->data, event_data->data_len );
                         // grab the json buffer
                         // {
-                        //   vpart: '{{ number virtual partition ID see ```vpart``` command. }}',
+                        //   vpart: {{ number virtual partition ID see ```vpart``` command. }},
                         //   code: '{{ string code }}',
                         //   action: '{{ string action }}',
                         //   arg: '{{ string argument }}'

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -444,7 +444,7 @@ void mqtt_on_connect(esp_mqtt_client_handle_t client)
                 { "availability_topic", topic+"/status" }
             }
         }
-                              );
+                                  );
     }
 
 }

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -260,6 +260,9 @@ static esp_err_t ad2_mqtt_event_handler(esp_mqtt_event_handle_t event_data)
                             if ( action.compare("EXIT") == 0 ) {
                                 ad2_exit_now(vpart);
                             } else
+                            if ( action.compare("CHIME_TOGGLE") == 0 ) {
+                                ad2_chime_toggle(code, vpart);
+                            } else
                             if ( action.compare("AUX_ALARM") == 0 ) {
                                 ad2_aux_alarm(vpart);
                             } else

--- a/components/ad2mqtt/ad2mqtt.cpp
+++ b/components/ad2mqtt/ad2mqtt.cpp
@@ -114,8 +114,8 @@ void mqtt_on_connect(esp_mqtt_client_handle_t client)
         topic += mqttclient_UUID;
         topic += "/" MQTT_COMMANDS_TOPIC;
         esp_mqtt_client_subscribe(client,
-                                topic.c_str(),
-                                MQTT_DEF_QOS);
+                                  topic.c_str(),
+                                  MQTT_DEF_QOS);
     }
 
     // Publish we are Online
@@ -250,32 +250,23 @@ static esp_err_t ad2_mqtt_event_handler(esp_mqtt_event_handle_t event_data)
 
                             if ( action.compare("DISARM") == 0 ) {
                                 ad2_disarm(code, vpart);
-                            } else
-                            if ( action.compare("ARM_STAY") == 0 ) {
+                            } else if ( action.compare("ARM_STAY") == 0 ) {
                                 ad2_arm_stay(code, vpart);
-                            } else
-                            if ( action.compare("ARM_AWAY") == 0 ) {
+                            } else if ( action.compare("ARM_AWAY") == 0 ) {
                                 ad2_arm_away(code, vpart);
-                            } else
-                            if ( action.compare("EXIT") == 0 ) {
+                            } else if ( action.compare("EXIT") == 0 ) {
                                 ad2_exit_now(vpart);
-                            } else
-                            if ( action.compare("CHIME_TOGGLE") == 0 ) {
+                            } else if ( action.compare("CHIME_TOGGLE") == 0 ) {
                                 ad2_chime_toggle(code, vpart);
-                            } else
-                            if ( action.compare("AUX_ALARM") == 0 ) {
+                            } else if ( action.compare("AUX_ALARM") == 0 ) {
                                 ad2_aux_alarm(vpart);
-                            } else
-                            if ( action.compare("PANIC_ALARM") == 0 ) {
+                            } else if ( action.compare("PANIC_ALARM") == 0 ) {
                                 ad2_panic_alarm(vpart);
-                            } else
-                            if ( action.compare("FIRE_ALARM") == 0 ) {
+                            } else if ( action.compare("FIRE_ALARM") == 0 ) {
                                 ad2_fire_alarm(vpart);
-                            } else
-                            if ( action.compare("BYPASS") == 0 ) {
+                            } else if ( action.compare("BYPASS") == 0 ) {
                                 ad2_bypass_zone(code, vpart, std::atoi(arg.c_str()));
-                            } else
-                            if ( action.compare("SEND_RAW") == 0 ) {
+                            } else if ( action.compare("SEND_RAW") == 0 ) {
                                 ad2_send(arg);
                             } else {
                                 // unknown command

--- a/components/ad2mqtt/ad2mqtt.h
+++ b/components/ad2mqtt/ad2mqtt.h
@@ -25,15 +25,8 @@
 #define _MQTT_H
 #if CONFIG_AD2IOT_MQTT_CLIENT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 void mqtt_register_cmds();
 void mqtt_init();
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* CONFIG_AD2IOT_MQTT_CLIENT */
 #endif /* _MQTT_H */

--- a/components/alarmdecoder-api/alarmdecoder_api.cpp
+++ b/components/alarmdecoder-api/alarmdecoder_api.cpp
@@ -650,6 +650,35 @@ void AlarmDecoderParser::setZoneString(uint8_t zone, const char* alpha)
     AD2ZoneAlpha[zone] = alpha;
 }
 
+/**
+ * @brief Return a type of a zone state. Use the AD2ZoneType string if found
+ * or the standard 'motion' template if not.
+ *
+ * @param [in]zone int value for the zone from 1-N
+ * @param [out]type std::string * type for the zone.
+ *
+ */
+void AlarmDecoderParser::getZoneType(uint8_t zone, std::string &type)
+{
+    if (AD2ZoneType.count(zone)) {
+        type = AD2ZoneType[zone];
+    } else {
+        type = "motion";
+    }
+}
+
+/**
+ * @brief Set the type of a zone.
+ *
+ * @param [in]zone int value for the zone from 1-N
+ *
+ * @return const char * type for the zone.
+ *
+ */
+void AlarmDecoderParser::setZoneType(uint8_t zone, const char* type)
+{
+    AD2ZoneType[zone] = type;
+}
 
 /**
  * @brief Consume bytes from an AlarmDecoder stream into a small ring
@@ -1349,7 +1378,7 @@ bool AlarmDecoderParser::put(uint8_t *buff, int8_t len)
                     } else {
                         //TODO: Error statistics tracking
 #if defined(IDF_VER)
-                        ESP_LOGE(TAG, "!ERR: BAD PROTOCOL PREFIX.");
+                        ESP_LOGE(TAG, "!ERR: BAD PROTOCOL PREFIX. '%s'", msg.c_str());
 #endif
                     }
                 }

--- a/components/alarmdecoder-api/alarmdecoder_api.h
+++ b/components/alarmdecoder-api/alarmdecoder_api.h
@@ -526,8 +526,14 @@ public:
     // get zone string using Alpha descriptor if found in AD2ZoneAlpha or use standard format 'ZONE XXX' if not found.
     void getZoneString(uint8_t zone, std::string &alpha);
 
-    // set zone string in AD2ZoneAlpha
+    // set zone alpha string in AD2ZoneAlpha
     void setZoneString(uint8_t zone, const char *alpha);
+
+    // get zone string using zone type if found in AD2ZoneType or use standard format 'motion' if not found.
+    void getZoneType(uint8_t zone, std::string &type);
+
+    // set zone type string in AD2ZoneType
+    void setZoneType(uint8_t zone, const char *alpha);
 
     // update firmware version trigger events to any subscribers
     void updateVersion(char *newversion);
@@ -609,7 +615,7 @@ public:
     typedef std::map<uint32_t, AD2VirtualPartitionState *> ad2pstates_t;
 
     /**
-    * @brief Zone descriptions
+    * @brief Zone config strings
     * The key is the zone number
     */
     typedef std::map<uint32_t, std::string> ad2zonealpha_t;
@@ -636,6 +642,9 @@ public:
 protected:
     // Zone to Alpha descriptor string.
     ad2zonealpha_t AD2ZoneAlpha;
+
+    // Zone to type string.
+    ad2zonealpha_t AD2ZoneType;
 
     // MAP of all partition states by mask.
     ad2pstates_t AD2PStates;

--- a/components/pushover/pushover.cpp
+++ b/components/pushover/pushover.cpp
@@ -741,6 +741,9 @@ void pushover_init()
 
                 // keep track of how many for user feedback.
                 subscribers++;
+            } else {
+                // incomplete switch call distructor.
+                es1->~AD2EventSearch();
             }
         }
     }

--- a/components/stsdk/stsdk_main.cpp
+++ b/components/stsdk/stsdk_main.cpp
@@ -1466,7 +1466,7 @@ void refresh_cmd_cb(IOT_CAP_HANDLE *handle,
 void update_firmware_cmd_cb(IOT_CAP_HANDLE *handle,
                             iot_cap_cmd_data_t *cmd_data, void *usr_data)
 {
-    ota_do_update(nullptr);
+    hal_ota_do_update(nullptr);
 }
 
 #ifdef __cplusplus

--- a/components/stsdk/stsdk_main.cpp
+++ b/components/stsdk/stsdk_main.cpp
@@ -464,7 +464,7 @@ void cap_fire_cmd_cb(struct caps_momentary_data *caps_data)
     if (fire_trigger_count >= 3) {
         ESP_LOGI(TAG, "Sending fire signal to panel.");
         // send a fire panic F1 button to the panel.
-        ad2_fire_alarm(AD2_DEFAULT_CODE_SLOT, AD2_DEFAULT_VPA_SLOT);
+        ad2_fire_alarm(AD2_DEFAULT_VPA_SLOT);
     } else {
         if (fire_trigger_timer) {
             xTimerReset(fire_trigger_timer, 1000 / portTICK_PERIOD_MS);
@@ -509,7 +509,7 @@ void cap_panic_alarm_cmd_cb(struct caps_momentary_data *caps_data)
     if (panic_trigger_count >= 3) {
         ESP_LOGI(TAG, "Sending panic alarm signal to panel.");
         // send PANIC command to the panel.
-        ad2_panic_alarm(AD2_DEFAULT_CODE_SLOT, AD2_DEFAULT_VPA_SLOT);
+        ad2_panic_alarm(AD2_DEFAULT_VPA_SLOT);
     } else {
         if (panic_trigger_timer) {
             xTimerReset(panic_trigger_timer, 1000 / portTICK_PERIOD_MS);
@@ -555,7 +555,7 @@ void cap_aux_alarm_cmd_cb(struct caps_momentary_data *caps_data)
     if (aux_trigger_count >= 3) {
         ESP_LOGI(TAG, "Sending aux alarm signal to panel.");
         // send AUX ALARM command to the panel.
-        ad2_aux_alarm(AD2_DEFAULT_CODE_SLOT, AD2_DEFAULT_VPA_SLOT);
+        ad2_aux_alarm(AD2_DEFAULT_VPA_SLOT);
     } else {
         if (aux_trigger_timer) {
             xTimerReset(aux_trigger_timer, 1000 / portTICK_PERIOD_MS);

--- a/components/twilio/twilio.cpp
+++ b/components/twilio/twilio.cpp
@@ -1000,6 +1000,9 @@ void twilio_init()
 
                 // keep track of how many for user feedback.
                 subscribers++;
+            } else {
+                // incomplete switch call distructor.
+                es1->~AD2EventSearch();
             }
         }
     }

--- a/components/webUI/webUI.cpp
+++ b/components/webUI/webUI.cpp
@@ -319,11 +319,11 @@ esp_err_t ad2ws_handler(httpd_req_t *req)
             } else if (sendbuf.rfind("<EXIT>", 0) == 0) {
                 ad2_exit_now(vpartID);
             } else if (sendbuf.rfind("<AUX_ALARM>", 0) == 0) {
-                ad2_aux_alarm(codeID, vpartID);
+                ad2_aux_alarm(vpartID);
             } else if (sendbuf.rfind("<PANIC_ALARM>", 0) == 0) {
-                ad2_panic_alarm(codeID, vpartID);
+                ad2_panic_alarm(vpartID);
             } else if (sendbuf.rfind("<FIRE_ALARM>", 0) == 0) {
-                ad2_fire_alarm(codeID, vpartID);
+                ad2_fire_alarm(vpartID);
             } else if (sendbuf.rfind("<BYPASS>", 0) == 0) {
                 // <BYPASS>XX
                 std::string zone = sendbuf.substr(8, string::npos);

--- a/main/ad2_cli_cmd.cpp
+++ b/main/ad2_cli_cmd.cpp
@@ -64,10 +64,10 @@ static void _cli_cmd_zone_event(char *string)
         if (ad2_copy_nth_arg(arg, string, 2, true) >= 0) {
             if (arg.length()) {
                 if (arg.compare("''") == 0) {
-                    ad2_printf_host(false, "Removing alpha for zone %i...\r\n", zone);
+                    ad2_printf_host(false, "Removing settings string for zone %i...\r\n", zone);
                     ad2_set_nv_slot_key_string(ZONES_ALPHA_CONFIG_KEY, zone, nullptr, arg.c_str());
                 } else {
-                    ad2_printf_host(false, "Setting alpha for zone %i to '%s'\r\n", zone, arg.c_str());
+                    ad2_printf_host(false, "Saving settings string for zone %i to '%s'\r\n", zone, arg.c_str());
                     ad2_set_nv_slot_key_string(ZONES_ALPHA_CONFIG_KEY, zone, nullptr, arg.c_str());
                 }
             }
@@ -75,7 +75,7 @@ static void _cli_cmd_zone_event(char *string)
             // show contents of this slot
             std::string buf;
             ad2_get_nv_slot_key_string(ZONES_ALPHA_CONFIG_KEY, zone, nullptr, buf);
-            ad2_printf_host(false, "The alpha for zone %i is '%s'\r\n", zone, buf.c_str());
+            ad2_printf_host(false, "The settings for zone %i is '%s'\r\n", zone, buf.c_str());
         }
     } else {
         ESP_LOGE(TAG, "%s: Error (args) invalid zone # (1-%i).", __func__, AD2_MAX_ZONES);
@@ -538,16 +538,16 @@ static struct cli_command cmd_list[] = {
     },
     {
         (char*)AD2_ZONE,(char*)
-        "- Manage zone strings.\r\n"
+        "- Manage zone settings string.\r\n"
         "  - ```" AD2_ZONE " {id} [value]```\r\n"
         "    - {id}\r\n"
         "      - Zone number 1-255.\r\n"
         "    - [value]\r\n"
-        "      - An alpha string for the zone.\r\n"
+        "      - json zone settings string for this zone.\r\n"
         "  - Examples\r\n"
-        "    - Set zone 1 alpha string.\r\n"
-        "      - ```" AD2_ZONE " 1 TESTING LAB```\r\n"
-        "    - Remove zone 1 alpha string.\r\n"
+        "    - Set zone 1 configuration string.\r\n"
+        "      - ```" AD2_ZONE " 1 {\"type\": \"smoke\", \"alpha\": \"TESTING LAB SMOKE\"}```\r\n"
+        "    - Remove zone 1 settings string.\r\n"
         "      - ```" AD2_ZONE " 1 ''```\r\n\r\n", _cli_cmd_zone_event
     },
     {

--- a/main/ad2_settings.h
+++ b/main/ad2_settings.h
@@ -24,7 +24,7 @@
 //#define AD2_STACK_REPORT
 
 // @brief Firmware version string.
-#define FIRMWARE_VERSION      "AD2IOT-1093"
+#define FIRMWARE_VERSION      "AD2IOT-1094"
 
 #if defined(CONFIG_STDK_IOT_CORE)
 #define FIRMWARE_BUILDFLAGS "stsdk"

--- a/main/ad2_utils.cpp
+++ b/main/ad2_utils.cpp
@@ -40,10 +40,6 @@ static const char *TAG = "AD2UTIL";
 #include "nvs_flash.h"
 #include "mbedtls/base64.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 /**
  * @brief Parse an acl string and add to our list of networks.
@@ -850,21 +846,17 @@ int ad2_copy_nth_arg(std::string &dest, char* src, int n, bool remaining)
 /**
  * @brief Send the ARM AWAY command to the alarm panel.
  *
- * @details using the code in slot codeId and address in
+ * @details using the given code and address in
  * slot vpartId send the correct command to the AD2 device
  * based upon the alarm type. Slots 0 are used as defaults.
  * The message will be sent using the AlarmDecoder 'K' protocol.
  *
- * @param [in]codeId int [0 - AD2_MAX_CODE]
+ * @param [in]code std::string &
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_arm_away(int codeId, int vpartId)
+void ad2_arm_away(std::string &code, int vpartId)
 {
-
-    // Get user code
-    std::string code;
-    ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
 
     int address = -1;
     ad2_get_nv_slot_key_int(VPART_CONFIG_KEY, vpartId, nullptr, &address);
@@ -889,7 +881,7 @@ void ad2_arm_away(int codeId, int vpartId)
 }
 
 /**
- * @brief Send the ARM STAY command to the alarm panel.
+ * @brief Send the ARM AWAY command to the alarm panel.
  *
  * @details using the code in slot codeId and address in
  * slot vpartId send the correct command to the AD2 device
@@ -900,12 +892,30 @@ void ad2_arm_away(int codeId, int vpartId)
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_arm_stay(int codeId, int vpartId)
+void ad2_arm_away(int codeId, int vpartId)
 {
 
     // Get user code
     std::string code;
     ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
+
+    ad2_arm_away(code, vpartId);
+}
+
+/**
+ * @brief Send the ARM STAY command to the alarm panel.
+ *
+ * @details using the given code and address in
+ * slot vpartId send the correct command to the AD2 device
+ * based upon the alarm type. Slots 0 are used as defaults.
+ * The message will be sent using the AlarmDecoder 'K' protocol.
+ *
+ * @param [in]code std::string &
+ * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
+ *
+ */
+void ad2_arm_stay(std::string &code, int vpartId)
+{
 
     int address = -1;
     ad2_get_nv_slot_key_int(VPART_CONFIG_KEY, vpartId, nullptr, &address);
@@ -929,7 +939,7 @@ void ad2_arm_stay(int codeId, int vpartId)
 }
 
 /**
- * @brief Send the DISARM command to the alarm panel.
+ * @brief Send the ARM STAY command to the alarm panel.
  *
  * @details using the code in slot codeId and address in
  * slot vpartId send the correct command to the AD2 device
@@ -940,13 +950,29 @@ void ad2_arm_stay(int codeId, int vpartId)
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_disarm(int codeId, int vpartId)
+void ad2_arm_stay(int codeId, int vpartId)
 {
-
     // Get user code
     std::string code;
     ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
 
+    ad2_arm_stay(code, vpartId);
+}
+
+/**
+ * @brief Send the DISARM command to the alarm panel.
+ *
+ * @details using a given code and address in
+ * slot vpartId send the correct command to the AD2 device
+ * based upon the alarm type. Slots 0 are used as defaults.
+ * The message will be sent using the AlarmDecoder 'K' protocol.
+ *
+ * @param [in]code std::string &
+ * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
+ *
+ */
+void ad2_disarm(std::string &code, int vpartId)
+{
     int address = -1;
     ad2_get_nv_slot_key_int(VPART_CONFIG_KEY, vpartId, nullptr, &address);
 
@@ -974,7 +1000,7 @@ void ad2_disarm(int codeId, int vpartId)
 }
 
 /**
- * @brief Toggle Chime mode.
+ * @brief Send the DISARM command to the alarm panel.
  *
  * @details using the code in slot codeId and address in
  * slot vpartId send the correct command to the AD2 device
@@ -985,12 +1011,29 @@ void ad2_disarm(int codeId, int vpartId)
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_chime_toggle(int codeId, int vpartId)
+void ad2_disarm(int codeId, int vpartId)
 {
-
     // Get user code
     std::string code;
     ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
+
+    ad2_disarm(code, vpartId);
+}
+
+/**
+ * @brief Toggle Chime mode.
+ *
+ * @details using a given code and address in
+ * slot vpartId send the correct command to the AD2 device
+ * based upon the alarm type. Slots 0 are used as defaults.
+ * The message will be sent using the AlarmDecoder 'K' protocol.
+ *
+ * @param [in]code std:string &
+ * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
+ *
+ */
+void ad2_chime_toggle(std::string &code, int vpartId)
+{
 
     int address = -1;
     ad2_get_nv_slot_key_int(VPART_CONFIG_KEY, vpartId, nullptr, &address);
@@ -1015,7 +1058,7 @@ void ad2_chime_toggle(int codeId, int vpartId)
 }
 
 /**
- * @brief Send the FIRE PANIC command to the alarm panel.
+ * @brief Toggle Chime mode.
  *
  * @details using the code in slot codeId and address in
  * slot vpartId send the correct command to the AD2 device
@@ -1026,7 +1069,28 @@ void ad2_chime_toggle(int codeId, int vpartId)
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_fire_alarm(int codeId, int vpartId)
+void ad2_chime_toggle(int codeId, int vpartId)
+{
+
+    // Get user code
+    std::string code;
+    ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
+
+    ad2_chime_toggle(code,vpartId);
+}
+
+/**
+ * @brief Send the FIRE PANIC command to the alarm panel.
+ *
+ * @details using the address in
+ * slot vpartId send the correct command to the AD2 device
+ * based upon the alarm type. Slots 0 are used as defaults.
+ * The message will be sent using the AlarmDecoder 'K' protocol.
+ *
+ * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
+ *
+ */
+void ad2_fire_alarm(int vpartId)
 {
 
     // Get the address/partition mask for multi partition support.
@@ -1043,16 +1107,15 @@ void ad2_fire_alarm(int codeId, int vpartId)
 /**
  * @brief Send the PANIC command to the alarm panel.
  *
- * @details using the code in slot codeId and address in
+ * @details using the address in
  * slot vpartId send the correct command to the AD2 device
  * based upon the alarm type. Slots 0 are used as defaults.
  * The message will be sent using the AlarmDecoder 'K' protocol.
  *
- * @param [in]codeId int [0 - AD2_MAX_CODE]
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_panic_alarm(int codeId, int vpartId)
+void ad2_panic_alarm(int vpartId)
 {
 
     // Get the address/partition mask for multi partition support.
@@ -1070,16 +1133,15 @@ void ad2_panic_alarm(int codeId, int vpartId)
 /**
  * @brief Send the AUX(medical) PANIC command to the alarm panel.
  *
- * @details using the code in slot codeId and address in
+ * @details using the address in
  * slot vpartId send the correct command to the AD2 device
  * based upon the alarm type. Slots 0 are used as defaults.
  * The message will be sent using the AlarmDecoder 'K' protocol.
  *
- * @param [in]codeId int [0 - AD2_MAX_CODE]
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
-void ad2_aux_alarm(int codeId, int vpartId)
+void ad2_aux_alarm(int vpartId)
 {
 
     // Get the address/partition mask for multi partition support.
@@ -1097,12 +1159,11 @@ void ad2_aux_alarm(int codeId, int vpartId)
 /**
  * @brief Send the EXIT now command to the alarm panel.
  *
- * @details using the code in slot codeId and address in
+ * @details using the address in
  * slot vpartId send the correct command to the AD2 device
  * based upon the alarm type. Slots 0 are used as defaults.
  * The message will be sent using the AlarmDecoder 'K' protocol.
  *
- * @param [in]codeId int [0 - AD2_MAX_CODE]
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  *
  */
@@ -1139,19 +1200,15 @@ void ad2_exit_now(int vpartId)
  * based upon the alarm type. Slots 0 are used as defaults.
  * The message will be sent using the AlarmDecoder 'K' protocol.
  *
- * @param [in]codeId int [0 - AD2_MAX_CODE]
+ * @param [in]code std::string &
  * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
  * @param [in]zone uint8_t[1-255] zone number
  *
  * FIXME: larger panels have 3 digit zones. Detect?
  *
  */
-void ad2_bypass_zone(int codeId, int vpartId, uint8_t zone)
+void ad2_bypass_zone(std::string &code, int vpartId, uint8_t zone)
 {
-
-    // Get user code
-    std::string code;
-    ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
 
     int address = -1;
     ad2_get_nv_slot_key_int(VPART_CONFIG_KEY, vpartId, nullptr, &address);
@@ -1173,6 +1230,30 @@ void ad2_bypass_zone(int codeId, int vpartId, uint8_t zone)
     } else {
         ESP_LOGE(TAG, "No partition state found for address %i. Waiting for messages from the AD2?", address);
     }
+}
+
+/**
+ * @brief Send a zone bypass command to the alarm panel.
+ *
+ * @details using the code in slot codeId and address in
+ * slot vpartId send the correct command to the AD2 device
+ * based upon the alarm type. Slots 0 are used as defaults.
+ * The message will be sent using the AlarmDecoder 'K' protocol.
+ *
+ * @param [in]codeId int [0 - AD2_MAX_CODE]
+ * @param [in]vpartId int [0 - AD2_MAX_VPARTITION]
+ * @param [in]zone uint8_t[1-255] zone number
+ *
+ * FIXME: larger panels have 3 digit zones. Detect?
+ *
+ */
+void ad2_bypass_zone(int codeId, int vpartId, uint8_t zone)
+{
+    // Get user code
+    std::string code;
+    ad2_get_nv_slot_key_string(CODES_CONFIG_KEY, codeId, nullptr, code);
+
+    ad2_bypass_zone(code, vpartId, zone);
 }
 
 /**
@@ -1752,6 +1833,3 @@ int ad2_give_host_console(void *owner)
     return res;
 }
 
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/main/ad2_utils.h
+++ b/main/ad2_utils.h
@@ -30,20 +30,20 @@
 // Debugging NVS
 //#define DEBUG_NVS
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // Communication with AD2* device / host
-
+void ad2_arm_away(std::string &code, int vpartId);
 void ad2_arm_away(int codeId, int vpartId);
+void ad2_arm_stay(std::string &code, int vpartId);
 void ad2_arm_stay(int codeId, int vpartId);
+void ad2_disarm(std::string &code, int vpartId);
 void ad2_disarm(int codeId, int vpartId);
+void ad2_chime_toggle(std::string &code, int vpartId);
 void ad2_chime_toggle(int codeId, int vpartId);
-void ad2_fire_alarm(int codeId, int vpartId);
-void ad2_panic_alarm(int codeId, int vpartId);
-void ad2_aux_alarm(int codeId, int vpartId);
+void ad2_fire_alarm(int vpartId);
+void ad2_panic_alarm(int vpartId);
+void ad2_aux_alarm(int vpartId);
 void ad2_exit_now(int vpartId);
+void ad2_bypass_zone(std::string &code, int vpartId, uint8_t zone);
 void ad2_bypass_zone(int codeId, int vpartId, uint8_t zone);
 void ad2_send(std::string &buf);
 AD2VirtualPartitionState *ad2_get_partition_state(int vpartId);
@@ -157,9 +157,6 @@ typedef bool (*ad2_http_sendQ_done_cb_t)(esp_err_t, esp_http_client_handle_t, es
 void ad2_init_http_sendQ();
 bool ad2_add_http_sendQ(esp_http_client_config_t*, ad2_http_sendQ_ready_cb_t, ad2_http_sendQ_done_cb_t);
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _AD2_UTILS_H */
 

--- a/main/alarmdecoder_main.cpp
+++ b/main/alarmdecoder_main.cpp
@@ -93,7 +93,7 @@ int g_init_done = 0;
 portMUX_TYPE spinlock = portMUX_INITIALIZER_UNLOCKED;
 
 // global host console access mutex
-extern SemaphoreHandle_t g_ad2_console_mutex = 0;
+SemaphoreHandle_t g_ad2_console_mutex = nullptr;
 
 // global AlarmDecoder parser class instance
 AlarmDecoderParser AD2Parse;

--- a/main/alarmdecoder_main.cpp
+++ b/main/alarmdecoder_main.cpp
@@ -721,13 +721,18 @@ void app_main()
         }
     }
 
-    // Load Zone alpha descriptors.
-    std::string alpha;
-    for (int n = 0; n <= AD2_MAX_ZONES; n++) {
-        alpha = "";
-        ad2_get_nv_slot_key_string(ZONES_ALPHA_CONFIG_KEY, n, nullptr, alpha);
-        if (alpha.length()) {
-            AD2Parse.setZoneString(n, alpha.c_str());
+    // Load Zone config string and save.
+    std::string config;
+    for (int n = 1; n <= AD2_MAX_ZONES; n++) {
+        config = "";
+        ad2_get_nv_slot_key_string(ZONES_ALPHA_CONFIG_KEY, n, nullptr, config);
+        if (config.length()) {
+            // Parse JSON string
+            cJSON *json = cJSON_Parse(config.c_str());
+            if (json) {
+                AD2Parse.setZoneString(n, cJSON_GetObjectItem(json, "alpha")->valuestring);
+                AD2Parse.setZoneType(n, cJSON_GetObjectItem(json, "type")->valuestring);
+            }
         }
     }
 

--- a/main/alarmdecoder_main.h
+++ b/main/alarmdecoder_main.h
@@ -64,6 +64,9 @@ extern int g_StopMainTask;
 // global critical section handle
 extern portMUX_TYPE spinlock;
 
+// global host console access mutex
+extern SemaphoreHandle_t g_ad2_console_mutex;
+
 // global AlarmDecoder parser class instance
 extern AlarmDecoderParser AD2Parse;
 

--- a/main/device_control.cpp
+++ b/main/device_control.cpp
@@ -974,9 +974,9 @@ bool hal_get_network_connected()
 /**
  * @brief Do an OTA update.
  */
-void hal_ota_do_update()
+void hal_ota_do_update(const char * arg)
 {
-    ota_do_update(nullptr);
+    ota_do_update((char*)arg);
 }
 
 

--- a/main/device_control.cpp
+++ b/main/device_control.cpp
@@ -38,6 +38,7 @@ static const char *TAG = "UARTCLI";
 #include "nvs_flash.h"
 
 // specific includes
+#include "ota_util.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -969,6 +970,16 @@ bool hal_get_network_connected()
 {
     return xEventGroupGetBits(g_ad2_net_event_group) & NET_STA_CONNECT_BIT;
 }
+
+/**
+ * @brief Do an OTA update.
+ */
+void hal_ota_do_update()
+{
+    ota_do_update(nullptr);
+}
+
+
 
 /**
  * @brief get CONNECTED state.

--- a/main/device_control.h
+++ b/main/device_control.h
@@ -138,7 +138,7 @@ void hal_set_eth_hostname(const char *);
 void hal_host_uart_init();
 void hal_ad2_reset();
 bool hal_get_network_connected();
-void hal_ota_do_update();
+void hal_ota_do_update(const char *);
 void hal_set_network_connected(bool);
 void hal_init_sd_card();
 void hal_get_socket_client_ip(int sockfd, std::string& IP);

--- a/main/device_control.h
+++ b/main/device_control.h
@@ -138,6 +138,7 @@ void hal_set_eth_hostname(const char *);
 void hal_host_uart_init();
 void hal_ad2_reset();
 bool hal_get_network_connected();
+void hal_ota_do_update();
 void hal_set_network_connected(bool);
 void hal_init_sd_card();
 void hal_get_socket_client_ip(int sockfd, std::string& IP);


### PR DESCRIPTION
Add missing logic for MQTT ```commands``` subscription with new ```commands``` enable/disable command. Misc minor cleanup of warnings. Refactor ad2_ helpers for arming to support code or codeID. Added initial support for Auto Discovery with Home Assistant and MQTT. 

Example Support for auto discovery in Home Assistant.

![image](https://user-images.githubusercontent.com/2042644/153801194-805814eb-4d37-4a18-a7d0-446e04817ff3.png)

### Added
  - MQTT
    - Enable/Disable feature for ```commands``` subscription with warning when enabling about security on public MQTT servers.
      - ```mqtt commands [Y|N]```
    - Missing logic behind ```commands``` subscription in the MQTT component.
      - Verbs: ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```
    - Update README with details on ```commands```, ```tprefix``` and ```dprefix```.
    - Add topic prefix command ```tprefix```.
    - Add discovery topic prefix command ```dprefix``` for MQTT auto discovery.
### Changed
  - Change ```zone``` command to expect a json string that is not currently validated as the last argument.
    - ```{"alpha": "zone alpha descriptor", "type": "zone type string"}```.
  - Refactor utils to allow for raw codes or codeID for ARM, DISARM, etc.
  - Remove unnecessary code passed to ad2_ functions that don't need it.
  - Remove forced C code sections. Need to clean all of them up now. Not an issue with newer build environment.
  - Fixed warning on g_ad2_console_mutex.
### Change log
  - [X] SM - MISC: Fix small memory leak in virtual switch usage in Pushover, Twilio and MQTT.
  - [X] SM - MQTT: Refactor publish function to make it easy to use in the code.
  - [X] SM - HAL: Added hal wrapper for ota_do_update(hal_ota_do_update) and updated any use of ota_do_update from outside of main.
  - [X] SM - MQTT: Added commands verbs ```[DISARM, ARM_STAY, FW_UPDATE, ARM_AWAY, EXIT, CHIME_TOGGLE, AUX_ALARM, PANIC_ALARM, FIRE_ALARM, BYPASS, SEND_RAW, FW_UPDATE]```.
  - [X] SM - MQTT: Support for Home Assistant/Others auto discovery.
  - [X] SM - MQTT: Add new command ```dprefix``` to set a prefix for publishing device config documents for MQTT auto discovery.
  - [X] SM - MQTT: Add new command ```commands``` to enable/disable commands subscription.
  - [X] SM - MQTT: Remove forced cdecl calling to use C++.
  - [X] SM - MQTT: Add new command ```tprefix``` to set a prefix for all topics on the broker.
  - [X] SM - MQTT: Add new command to define signon messages to publish.
  - [X] SM - CORE: Refactor ad2_ routines to arm, disarm etc to support raw code as well as code id from ```code``` command.
  - [X] SM - CORE: ad2_utils remove forced cdecl calling to use C++ instead. TODO: I can now safely remove the extern 'C' from everything with the current build tools.
  - [X] SM - CORE: Fixed a few compiler warnings re. external with init.
